### PR TITLE
Fixing "\l__acro_foreign_format_prop undefined"

### DIFF
--- a/setup/preamble.tex
+++ b/setup/preamble.tex
@@ -180,6 +180,11 @@
 % Setup for acro v2
 \acsetup{only-used=true, page-style=none}
 
+% Fix acro error
+\ExplSyntaxOn
+\prop_new:N \l__acro_foreign_format_prop
+\ExplSyntaxOff
+
 \usepackage[toc]{glossaries}
 \usepackage{longtable}
 


### PR DESCRIPTION
The downgrade of acro means that we get an error: "Variable \l__acro_foreign_format_prop undefined", this fixes that with minimal effort.