### PR TITLE
Make the acronym list a chapter

### DIFF
--- a/master.tex
+++ b/master.tex
@@ -35,8 +35,7 @@
 
 % Printer Forklaring til forkortelser og ordbog
 % acro v2 syntax:
-\printacronyms[]
-\addcontentsline{toc}{chapter}{Acronyms} 
+\printacronyms[heading={chapter*}]
 \printglossaries
 \pagebreak
 

--- a/master.tex
+++ b/master.tex
@@ -36,6 +36,7 @@
 % Printer Forklaring til forkortelser og ordbog
 % acro v2 syntax:
 \printacronyms[heading={chapter*}]
+\addcontentsline{toc}{chapter}{Acronyms} 
 \printglossaries
 \pagebreak
 


### PR DESCRIPTION
The acronym list had the wrong size heading and placed itself on the preface, this fixes that by making it a chapter* instead of the default of section*