### PR TITLE
Fixed errors from myRef macros being removed

### DIFF
--- a/sections/6.1- introduction.tex
+++ b/sections/6.1- introduction.tex
@@ -65,9 +65,9 @@ and this.
 \paragraph{A Paragraph}
 You can also use paragraph titles which look like this.
 
-This is a reference to \myRef{Table}{tab:table}
+This is a reference to \autoref{tab:table}
 \newline
-This is a reference with a page number to \myRefPage{Table}{tab:table}
+This is a reference with a page number to \myAutoRefOnPage{tab:table}
 
 \subparagraph{A Subparagraph} Moreover, you can also use subparagraph titles which look like this\todo{Is it possible to add a subsubparagraph?}. They have a small indentation as opposed to the paragraph titles.
 


### PR DESCRIPTION
Since the myRef macros were removed, but still used in 6.1- introduction.tex, we got errors when loading it in