### PR TITLE
Allow possessive (genitive) endings on acronyms

### DIFF
--- a/setup/preamble.tex
+++ b/setup/preamble.tex
@@ -180,6 +180,26 @@
 % Setup for acro v2
 \acsetup{only-used=true, page-style=none}
 
+\ProvideAcroEnding {possessive} {'s} {'s}
+    
+\ExplSyntaxOn
+\NewAcroCommand \acg
+  {
+    \acro_possessive:
+    \acro_use:n {#1}
+  }
+\NewAcroCommand \acsg
+  {
+    \acro_possessive:
+    \acro_short:n {#1}
+  }
+\NewAcroCommand \aclg
+  {
+    \acro_possessive:
+    \acro_long:n {#1}
+  }
+\ExplSyntaxOff
+
 % Fix acro error
 \ExplSyntaxOn
 \prop_new:N \l__acro_foreign_format_prop


### PR DESCRIPTION
Based on https://latex.org/forum/viewtopic.php?t=24989

This would let you use `\acg`, `\acsg` and `\aclg` to use a acronym with a possessive ending (<acro>'s).

Example: `\acg{cfcs} evaluations conclude` -> `Centre for Cyber Security’s (CFCS’s) evaluations`