### PR TITLE
No need to hyperlink the page count

### DIFF
--- a/setup/macros.tex
+++ b/setup/macros.tex
@@ -98,7 +98,7 @@
     \textbf{Participant(s):}\\ #5\bigskip\par
     \textbf{Supervisor(s):}\\ #6\bigskip\par
     \textbf{Copies:} #7\bigskip\par
-    \textbf{Number of pages:} \pageref{myLastPage}\bigskip\par
+    \textbf{Number of pages:} \pageref*{myLastPage}\bigskip\par
     \textbf{Date of Completion:}\\ #8
   }
 }
@@ -113,7 +113,7 @@
     \textbf{Deltager(e):}\\ #5\bigskip\par
     \textbf{Vejleder(e):}\\ #6\bigskip\par
     \textbf{Oplagstal:} #7\bigskip\par
-    \textbf{Sidetal:} \pageref{myLastPage}\bigskip\par
+    \textbf{Sidetal:} \pageref*{myLastPage}\bigskip\par
     \textbf{Afleveringsdato:}\\ #8
   }
 }


### PR DESCRIPTION
The page count on the titlepages were also hyperlinks, that doesn't actually make sense to have. This simple PR fixes that.